### PR TITLE
init

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/unbound
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.2
+      - uses: docker/metadata-action@v5.5.1
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM alpine:3.19 as builder
+ARG UNBOUND_VERSION=1.19.3
+
+WORKDIR /build
+RUN apk add curl build-base openssl-dev openssl-libs-static expat-dev expat-static libevent-dev libevent-static protobuf-c-dev protobuf-c-compiler && \
+    curl -sSL -o root.hints https://www.internic.net/domain/named.root && \
+    curl -sSL https://nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz | tar xz --strip 1 && \
+    ./configure \
+      --disable-flto \
+      --disable-rpath \
+      --enable-dnstap \
+      --enable-fully-static \
+      --enable-subnet \
+      --enable-tfo-client \
+      --enable-tfo-server \
+      --localstatedir=/var \
+      --prefix=/usr \
+      --runstatedir=/run \
+      --sysconfdir=/etc \
+      --with-chroot-dir="" \
+      --with-libevent \
+      --with-pidfile=/run/unbound.pid \
+      --with-pthreads \
+      --with-ssl && \
+    make install
+
+
+FROM alpine:3.19
+
+WORKDIR /etc/unbound
+
+COPY --from=builder /usr/sbin/unbound /usr/sbin/unbound
+COPY --from=builder /usr/sbin/unbound-anchor /usr/sbin/unbound-anchor
+COPY --from=builder /build/root.hints /etc/unbound/root.hints
+
+RUN addgroup -S -g 1000 unbound && \
+    adduser -S -D -H -u 1000 -h /etc/unbound -G unbound unbound && \
+    install -o unbound -g unbound -m 0755 -d /var/lib/unbound && \
+    ( unbound-anchor -a /var/lib/unbound/root.key -r /etc/unbound/root.hints || true ) && \
+    chown unbound:unbound /var/lib/unbound/root.key
+
+EXPOSE 53/udp
+ENTRYPOINT ["/usr/sbin/unbound", "-d"]


### PR DESCRIPTION
```
# unbound -V
Version 1.19.3

Configure line: --disable-flto --disable-rpath --enable-dnstap --enable-fully-static --enable-subnet --enable-tfo-client --enable-tfo-server --localstatedir=/var --prefix=/usr --runstatedir=/run --sysconfdir=/etc --with-chroot-dir= --with-libevent --with-pidfile=/run/unbound.pid --with-pthreads --with-ssl
Linked libs: libevent 2.1.12-stable (it uses epoll), OpenSSL 3.1.4 24 Oct 2023
Linked modules: dns64 subnetcache respip validator iterator
TCP Fastopen feature available

BSD licensed, see LICENSE in source package for details.
Report bugs to unbound-bugs@nlnetlabs.nl or https://github.com/NLnetLabs/unbound/issues
```